### PR TITLE
Improved package citation

### DIFF
--- a/inst/CITATION
+++ b/inst/CITATION
@@ -1,24 +1,20 @@
 bibentry(bibtype = "Article",
-  title        = "{libstable}: Fast, Parallel, and High-Precision Computation of $\alpha$-Stable Distributions in {R}, {C/C++}, and {MATLAB}",
+  title        = "{libstable}: Fast, Parallel, and High-Precision Computation of $\\alpha$-Stable Distributions in {R}, {C/C++}, and {MATLAB}",
   author       = c(person(given = "Javier",
                           family = "Royuela-del-Val",
-                          email = "jroyval@lpi.tel.uva.es"),
+                          email = "jroyval@lpi.tel.uva.es",
+                          comment = c(ORCID = "0000-0002-4347-2783")),
                    person(given = "Federico",
-                          family = "Simmross-Wattenberg"),
+                          family = "Simmross-Wattenberg",
+                          comment = c(ORCID = "0000-0001-9534-1016")),
                    person(given = "Carlos",
-                          family = "Alberola-L{\\'o}pez")),
+                          family = "Alberola-L{\\'o}pez",
+                          comment = c(ORCID = "0000-0003-3684-0055"))),
   journal      = "Journal of Statistical Software",
   year         = "2017",
   volume       = "78",
   number       = "1",
   pages        = "1--25",
   doi          = "10.18637/jss.v078.i01",
-
-  header       = "To cite libstable/libstable4u/v78i01-replication.tar.gz in publications use:",
-  textVersion  =
-  paste("Javier Royuela-del-Val, Federico Simmross-Wattenberg, Carlos Alberola-Lopez (2017).",
-        "libstable: Fast, Parallel, and High-Precision Computation of $\alpha$-Stable Distributions in R, C/C++, and MATLAB.",
-        "Journal of Statistical Software, 78(1), 1-25.",
-        "doi:10.18637/jss.v078.i01")
+  header       = "To cite libstable4u in publications use:"
 )
-


### PR DESCRIPTION
Bruce @swihart, thank you for resurrecting this package. This PR includes an improved package citation for `libstable4u`.

**Motivation:** I just noticed that the `\alpha` in the title of the `CITATION` file was malformatted. It should have been `\\alpha` (with double backslash) because it is in an R string and not `\alpha` (with a single backslash). In the latter version `\a` is interpreted as an "alert" (like `\n` would be a "newline").

**Changes:** Given that I had to change the file anyway I did a couple of further improvements.

- Added ORCIDs for all authors.
- Omitted the textVersion because by now R auto-generates this and it does not have to be hard-coded.
- The header is simplified.

**Background:** We noticed this problem when generating DOIs for all R packages (see https://fosstodon.org/@zeileis/112597049943483012) because the title string could not be formatted properly. Hence it would be great if you could release a new version of the package to CRAN soon. Then we can also register a DOI for `libstable4u`.